### PR TITLE
Following discussion with a number of colleagues this PR covers issue…

### DIFF
--- a/charter.html
+++ b/charter.html
@@ -75,17 +75,28 @@
       <h1 id="title">PROPOSED Private Advertising Technology Working Group Charter</h1>
       <!-- delete PROPOSED after AC review completed -->
 
-      <p class="mission">The <strong>mission</strong> of the <a href=""Private Advertising Technology Working Group</a>
-         motivated by the <a href="https://www.w3.org/2001/tag/doc/ethical-web-principles/">W3C TAG Ethical Web Principles</a>, is to
-         specify web features and APIs that support advertising while
-         acting in the interests of users, in particular providing strong
-         privacy assurances.  The Working Group welcomes participation from
-         browser vendors, OS vendors, mobile application vendors, advertisers,
-         publishers, ad buyers, advertising platforms and intermediaries,
-         privacy advocates, web application developers, and other interested
-         parties.
+      <p class="mission">The <strong>mission</strong> of the 
+        <a href="#">Private Advertising Technology Working Group</a>
+        motivated by the need to develop open standards supporting the development of the Open Web in accordance with 
+        the <a href="https://www.w3.org/2009/12/Member-Agreement">W3C Member Agreement</a> and 
+        <a href="https://www.w3.org/2021/Process-20211102">W3C Process</a> while taking into account all elements of the
+        W3C Process, is to specify solutions that support advertising while acting in the interests of users, in 
+        particular providing Privacy [1]. The Working Group welcomes participation from all W3C Members that may wish to
+        contribute, in particular, from browser users and vendors, OS vendors, application vendors, advertisers,
+        publishers, ad buyers, advertising platforms and intermediaries, privacy advocates, web application developers,
+        and other interested parties.
       </p>                                                                
 
+      <h5 id="mission-notes">[1] Privacy Note</h5>
+      <p>
+        <i>
+          “Privacy” needs more definition. What is private or public is unlikely to be the issue. Protection of personal
+          data is likely to be the issue. Here the likely implication is that the W3C group should be seeking to ensure
+          technical neutrality and avoid infringement of data protection laws (which could be listed) or misuse of
+          personal data as defined in data protection law.
+        </i>
+      </p>
+      
       <div class="noprint">
         <p class="join"><a href="https://www.w3.org/groups/wg/[shortname]/join">Join the Private Web Advertising Working Group.</a></p>
       </div>
@@ -160,22 +171,20 @@
       <section id="scope" class="scope">
         <h2>Scope</h2>
         <p>
-            The Working Group will specify new web platform features intended to
-            be implemented in browsers or similar user agents. The purpose of
-            these features is to support web advertising and provide users with
-            privacy guarantees with a strong technical basis.
+          The Working Group will specify solutions and essential inputs. The purpose of these solutions is to support
+          web advertising and user's Privacy.
         </p>
         <p>
-          The Working Group may consider designs that allow user agents for the
-          same user — including non-browser agents, like Operating Systems — to
-          collaborate in providing advertising features.
-          </p>
+          The Working Group may consider solutions that allow user's to receive a seamless experience across all the
+          devices they use.
         </p>
+      </section>
 
-        <section id="section-out-of-scope">
-          <h3 id="out-of-scope">Out of Scope</h3>
-          <p>Features that support advertising but provide privacy by means that are primarily non-technical should be proposed elsewhere.</p>
-        </section>
+      <section id="section-out-of-scope">
+        <h3 id="out-of-scope">Out of Scope</h3>
+        <p>
+          Features and solutions that add new web browser APIs specifically for the purposes of web advertising.
+        </p>
       </section>
 
       <section id="deliverables">
@@ -251,7 +260,7 @@
       </section>
 
 	<section id="success-criteria">
-	  <h2>Success Criteria</h2>
+	  <h2>Success Criteria [2]</h2>
 	  <p>In order to advance to <a href="https://www.w3.org/Consortium/Process/#RecsPR" title="Proposed Recommendation">Proposed Recommendation</a>, each normative specification is expected to have <a href="https://www.w3.org/Consortium/Process/#implementation-experience">at least two independent implementations</a> of every feature defined in the specification.</p>
 
 	  <p>
@@ -261,6 +270,11 @@
 
           <p>Normative specifications which have user-facing features should contain a section on accessibility that describes the benefits and impacts, including ways specification features can be used to address them, and recommendations for maximizing accessibility in implementations.</p>
 	</section>
+
+  <h5 id="success-criteria-notes">[2] Note on Success Criteria</h5>
+  <p>
+    <i>There are many issues identified in relation to implementators creating defacto standards without broad agreement. Success Criteria needs more time for debate and discussion.</i>
+  </p>
 
       <section id="coordination">
         <h2>Coordination</h2>
@@ -334,8 +348,6 @@ To be successful, this Working Group is expected to have 6 or more active partic
         <p>
           The group also welcomes non-Members to contribute technical submissions for consideration upon their agreement to the terms of the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a>.
         </p>
-        <p>Participants in the group are required (by the <a href="https://www.w3.org/Consortium/Process/#ParticipationCriteria">W3C Process</a>) to follow the
-          W3C <a href="https://www.w3.org/Consortium/cepc/">Code of Ethics and Professional Conduct</a>.</p>
       </section>
 
       <section id="communication">
@@ -435,6 +447,17 @@ To be successful, this Working Group is expected to have 6 or more active partic
           For more information about disclosure obligations for this group, please see the <a href="https://www.w3.org/groups/wg/[shortname]/ipr">licensing information</a>.
         </p>
 
+
+      <section id="datapolicy">
+        <h2>
+          Data Policy
+        </h2>
+        <p>
+          The W3C patent policy addresses the need for those that have patents over essential inputs to license them on FRAND terms to all Members. Inputs that may not be protected by patents but may be needed by others for implementation of a specification or standard also need to be available to all on FRAND terms to avoid the same issue of inputs being available to some and not others from arising.
+        </p>
+        <p>
+          This Working Group operates under the <a href="https://www.w3.org/Consortium/Legal/2017/antitrust-guidance">W3C antitrust policy</a>. To promote the widest adoption, W3C seeks to issue specifications that can be implemented on a Royalty-Free basis. Essential Inputs are all inputs owned or controlled by a Member for which there is no alternative and which are required for the implementation of each specification. All essential inputs shall be made available on FRAND terms by Members of this group.
+        </p>
 
       <section id="licensing">
         <h2>Licensing</h2>


### PR DESCRIPTION
…s #5, #6, #8, and #16.

Solutions has been used to avoid steering the group towards specific outcomes. This relates to [#5]( https://github.com/patcg/patwg-charter/issues/5).

Privacy needs to be defined and used consistently throughout and relates to [#6]( https://github.com/patcg/patwg-charter/issues/6). The PR does not address this but capitalizes the term and suggests a section to achieve this is added.

The Scope has been modified to avoid excluding solutions that address the problem the group seeks to resolve utilising a combination of different disciplines and to avoid solutions that only web browsers can implement. This relates to [#8]( https://github.com/patcg/patwg-charter/issues/8).

Regarding access to data. References the patent policy and applies access to input data under FRAND terms and principles. This will address the issue concerning data access and aligns with the existing precedent associated with those that have something that is needed to make the specification working making all those things available to others. See the new chapter on Data Policy following Patent Policy. This relates to [#16]( https://github.com/patcg/patwg-charter/issues/16).

The Success Criteria are not clear and need further work.

Included several other changes in the PR to better align the document with the W3C Process which we identified during our review. For example the call out of specific sections of the W3C Process are removed as these are not needed and emphasis some elements over others. The W3C Antitrust Guidelines are now referenced as these don’t form part of the W3C Process.

This PR is a start to move the charter in a better direction rather than a finished charter.

My colleagues advise that reviewers from Apple, Facebook, Google, and Microsoft, might wish to contact their colleagues Per Hellstrom, Tim Lamb, Oliver Bethell, and Greg Sivinski respectively for their views on the modifications.