### PR TITLE
propose a meeting schedule; remove empty history lines

### DIFF
--- a/charter.html
+++ b/charter.html
@@ -151,13 +151,6 @@
           </tr>
         </table>
 
-        <p class="issue"><b>Note:</b> The <a href="https://www.w3.org/Consortium/Process/#WGCharter">W3C Process Document</a> requires “The level of confidentiality of the group's proceedings and deliverables”; however, it does not mandate where this appears. Since all W3C Working Groups should be chartered as public, this notice has been moved from the essentials table to the <a href="#public">communication section</a>.</p>
-      </section>
-
-      <section id="background" class="background">
-        <p><i class="todo">Brief background of landscape, technology, and relationship to the Web, users, developers, implementers, and industry.</i></p>
-      </section>
-
       <section id="scope" class="scope">
         <h2>Scope</h2>
         <p>
@@ -192,7 +185,7 @@
           Deliverables
         </h2>
 
-        <p><i class="todo">Updated document status is available on the <a href="https://www.w3.org/groups/wg/[shortname]/publications">group publication status page</a>. [or link to a page this group prefers to use]</i></p>
+        <p><i class="todo">Updated document status is available on the <a href="https://www.w3.org/groups/wg/[shortname]/publications">group publication status page</a>.</i></p>
 
         <p><i>Draft state</i> indicates the state of the deliverable at the time of the charter approval.
           The Working Group intends to publish the latest state of their work as Candidate Recommendation (with Snapshots) and does not intend to advance their documents further.</p>
@@ -480,7 +473,6 @@ To be successful, this Working Group is expected to have 6 or more active partic
           <h3>
             Charter History
           </h3>
-          <p class="issue"><b>Note:</b>Display this table and update it when appropriate. Requirements for charter extension history are documented in the <a href="https://www.w3.org/Guide/process/charter.html#extension">Charter Guidebook (section 4)</a>.</p>
 
           <p>The following table lists details of all changes from the initial charter, per the <a href="https://www.w3.org/Consortium/Process/#CharterReview">W3C Process Document (section 4.3, Advisory Committee Review of a Charter)</a>:</p>
 
@@ -542,7 +534,7 @@ To be successful, this Working Group is expected to have 6 or more active partic
 
       <p class="copyright">
         <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> ©
-        <i class="todo">[yyyy]</i>
+        2022
         <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup>
         (
         <a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
@@ -554,7 +546,7 @@ To be successful, this Working Group is expected to have 6 or more active partic
         <abbr title="World Wide Web Consortium">W3C</abbr> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.
       </p>
       <hr>
-      <p><span class='todo'><a href="https://github.com/w3c/charter-drafts">Yes, it's on GitHub!</a>.</span></p>
+      <p><a href="https://github.com/patcg/patwg-charter/">Yes, it's on GitHub!</a>.</p>
     </footer>
 
   </body>

--- a/charter.html
+++ b/charter.html
@@ -144,7 +144,7 @@
               Meeting Schedule
             </th>
             <td>
-              <strong>Teleconferences:</strong> <i class="todo">topic-specific calls may be held</i> or <i class="todo">somthing else</i>
+              <strong>Teleconferences:</strong> We expect to meet every 1-3 months for longer-than-hour blocks, which might be spread over several days
               <br>
               <strong>Face-to-face:</strong> we will meet during the W3C's annual Technical Plenary week; additional face-to-face meetings may be scheduled by consent of the participants, usually no more than 3 per year.
             </td>
@@ -512,34 +512,6 @@ To be successful, this Working Group is expected to have 6 or more active partic
                 </td>
                 <td>
                   <i class="todo">none</i>
-                </td>
-              </tr>
-              <tr>
-                <th>
-                  <a class="todo" href="">Charter Extension</a>
-                </th>
-                <td>
-                  <i class="todo">[dd monthname yyyy]</i>
-                </td>
-                <td>
-                  <i class="todo">[dd monthname yyyy]</i>
-                </td>
-                <td>
-                  <i class="todo">none</i>
-                </td>
-              </tr>
-              <tr>
-                <th>
-                  <a class="todo" href="">Rechartered</a>
-                </th>
-                <td>
-                  <i class="todo">[dd monthname yyyy]</i>
-                </td>
-                <td>
-                  <i class="todo">[dd monthname yyyy]</i>
-                </td>
-                <td>
-                  <p class="todo">[description of change to charter, with link to new deliverable item in charter] <b>Note:</b> use the class <code>new</code> for all new deliverables, for ease of recognition.</p>
                 </td>
               </tr>
             </tbody>


### PR DESCRIPTION
Several cleanups:

- proposed a meeting schedule
- removed empty history lines
- removed empty sections and instructions to charter authors
- updated copyright date
- updated github link at end of document