### PR TITLE
'technical measures' scope front and center

### DIFF
--- a/charter.html
+++ b/charter.html
@@ -80,7 +80,7 @@
          motivated by the <a href="https://www.w3.org/2001/tag/doc/ethical-web-principles/">W3C TAG Ethical Web Principles</a>, is to
          specify web features and APIs that support advertising while
          acting in the interests of users, in particular providing strong
-         privacy assurances using technical means.  The Working Group welcomes participation from
+         privacy assurances using predominantly technical means.  The Working Group welcomes participation from
          browser vendors, OS vendors, mobile application vendors, advertisers,
          publishers, ad buyers, advertising platforms and intermediaries,
          privacy advocates, web application developers, and other interested

--- a/charter.html
+++ b/charter.html
@@ -80,7 +80,7 @@
          motivated by the <a href="https://www.w3.org/2001/tag/doc/ethical-web-principles/">W3C TAG Ethical Web Principles</a>, is to
          specify web features and APIs that support advertising while
          acting in the interests of users, in particular providing strong
-         privacy assurances.  The Working Group welcomes participation from
+         privacy assurances using technical means.  The Working Group welcomes participation from
          browser vendors, OS vendors, mobile application vendors, advertisers,
          publishers, ad buyers, advertising platforms and intermediaries,
          privacy advocates, web application developers, and other interested


### PR DESCRIPTION
I propose to put the "technical measures" (or "means") scope restriction front and center.  This is purely a style thing, and I have no objection if you reject the change.