### PR TITLE
remove special case for PATCG feedback

### DIFF
--- a/charter.html
+++ b/charter.html
@@ -289,9 +289,6 @@
           such that the group is encouraged to coordinate with the appropriate groups at the WHATWG, Ecma, and IETF as needed.
         </p>
 
-        <p>
-          The WG will coordinate with the Private Advertising Technology Community Group to solicit feedback from a wider community of interest. At any time, but always when a specification is undergoing a <a href="https://www.w3.org/2021/Process-20211102/#rec-track" title="The W3C Recommendation Track">state change</a>, the WG will ask the CG for feedback. The WG will allow the CG at least 4 weeks to gather that feedback.
-
         <p>Additional technical coordination with the following Groups will be made, per the <a href="https://www.w3.org/Consortium/Process/#WGCharter">W3C Process Document</a>:</p>
 
         <section>


### PR DESCRIPTION
The PATWG will be working in public, which will give PATCG members and everyone else opportunities to contribute.  I see no need to special-case PATCG, and certainly not to apply a time delay for their feedback (v. feedback from anyone else).