### PR TITLE
Addressing #35 - making explicit that proposals should detail the data they intend to use and return.

### DIFF
--- a/charter.html
+++ b/charter.html
@@ -267,7 +267,7 @@
     It is expected that to reach the Candidate Recommendation Snapshot stage, each normative
     specification is expected to have <a href="https://www.w3.org/Consortium/Process/#implementation-experience">at least two independent implementations</a> of every feature defined in the specification.</p>
 
-          <p>Each normative specification should contain separate sections detailing anticipated data inputs and outputs, all known security and privacy implications for implementers, Web authors, and end users.</p>
+          <p>Each normative specification should contain separate sections detailing all known security and privacy implications for implementers, Web authors, and end users. Those sections should include documentation of data inputs and outputs.</p>
 
           <p>There should be testing plans for each specification, starting from the earliest drafts.</p>
 

--- a/charter.html
+++ b/charter.html
@@ -267,7 +267,7 @@
     It is expected that to reach the Candidate Recommendation Snapshot stage, each normative
     specification is expected to have <a href="https://www.w3.org/Consortium/Process/#implementation-experience">at least two independent implementations</a> of every feature defined in the specification.</p>
 
-          <p>Each normative specification should contain separate sections detailing all known security and privacy implications for implementers, Web authors, and end users.</p>
+          <p>Each normative specification should contain separate sections detailing anticipated data inputs and outputs, all known security and privacy implications for implementers, Web authors, and end users.</p>
 
           <p>There should be testing plans for each specification, starting from the earliest drafts.</p>
 


### PR DESCRIPTION
I would assume that most proposals would include a section or sections on this already, but I have no problem making that explicit considering our problem space. Making the change in response to [@bmayd](https://github.com/bmayd)'s input. What do people think? 

(EDIT: in case this isn't clear in respect to our other discussion this is in regard to what types of data and where they come from, not the actual data points themselves. I'd be very open to any edits that make this clearer.)