### PR TITLE
Trade offs should be clear in the specifications

### DIFF
--- a/charter.html
+++ b/charter.html
@@ -268,10 +268,14 @@
     specification is expected to have <a href="https://www.w3.org/Consortium/Process/#implementation-experience">at least two independent implementations</a> of every feature defined in the specification.</p>
 
           <p>Each normative specification should contain separate sections detailing all known security and privacy implications for implementers, Web authors, and end users.</p>
+          
+          <p>Any proposed feature should reduce the data available about a user.</p>
 
           <p>There should be testing plans for each specification, starting from the earliest drafts.</p>
 
     <p>Normative specifications which have user-facing features should contain a section on accessibility that describes the benefits and impacts, including ways specification features can be used to address them, and recommendations for maximizing accessibility in implementations.</p>
+        
+          <p>In considering features, the group will state, during the development of those features or in the text of the document, what utility is aimed to be provided and what specific risks it aims to address. Proposals should clearly state business factors and user risks they will consider and how they will decrease such risks and what safeguards will be put in place to decrease such risk and continue to enable the business factors they wish to preserve</p>
         </section>
 
       <section id="coordination">


### PR DESCRIPTION
Objections included concerns that the charter did not list trade offs in utility vs privacy that would be considered during operation and consideration of specifications. Since specifications may have different concerns around utility and privacy it seems inappropriate to try and list these in the charter. Instead this change requires those concerns to be addressed on a per proposal and feature basis.

See https://github.com/patcg/patwg-charter/issues/44 to help with understanding this issue.