### PR TITLE
Establish out-of-browser function accessibility

### DIFF
--- a/charter.html
+++ b/charter.html
@@ -272,6 +272,8 @@
           <p>There should be testing plans for each specification, starting from the earliest drafts.</p>
 
     <p>Normative specifications which have user-facing features should contain a section on accessibility that describes the benefits and impacts, including ways specification features can be used to address them, and recommendations for maximizing accessibility in implementations.</p>
+          
+          <p>Non-browser-based functionality in any feature should be clearly established in such a way that any entity who can fill that role in the ecosystem is permitted to do so.</p>
         </section>
 
       <section id="coordination">


### PR DESCRIPTION
Intended to address: objections that were concerned that specifications that establish non-browser functionality and risk mitigation might be limited only to browser manufacturers.

See https://github.com/patcg/patwg-charter/issues/44 to help with understanding this issue.