### PR TITLE
Design teams set up to address antitrust concerns

### DIFF
--- a/charter.html
+++ b/charter.html
@@ -374,6 +374,7 @@ To be successful, this Working Group is expected to have 6 or more active partic
         <p>
           At the discretion of the Chairs and subject to a consensus call, the Working Group may designate a Design Team to study a particular subject, and report back to the Working Group their findings and a recommendation. These Design Teams shall consist of a small group of volunteers who commit to investing significant amounts of time on the task over a short, time-bound, period.
         </p>
+        <p>When volunteers are available the chairs will endeavor to make such Design Teams filled with a diverse set of stakeholders including participants at multiple levels of the ad ecosystem</p>
         <p>
           This Working Group primarily conducts its technical work in the PATWG GitHub repository, which is configured to send all issues and pull requests to the public mailing list: public-[email-list]@w3.org (archive). The public is invited to review, discuss and contribute to this work.         </p>
         <p>

--- a/charter.html
+++ b/charter.html
@@ -374,7 +374,7 @@ To be successful, this Working Group is expected to have 6 or more active partic
         <p>
           At the discretion of the Chairs and subject to a consensus call, the Working Group may designate a Design Team to study a particular subject, and report back to the Working Group their findings and a recommendation. These Design Teams shall consist of a small group of volunteers who commit to investing significant amounts of time on the task over a short, time-bound, period.
         </p>
-        <p>When volunteers are available the chairs will endeavor to make such Design Teams filled with a diverse set of stakeholders including participants at multiple levels of the ad ecosystem</p>
+        <p>When volunteers are available the chairs will endeavor to make such Design Teams filled with a diverse set of stakeholders including participants at multiple levels of the ad ecosystem.</p>
         <p>
           This Working Group primarily conducts its technical work in the PATWG GitHub repository, which is configured to send all issues and pull requests to the public mailing list: public-[email-list]@w3.org (archive). The public is invited to review, discuss and contribute to this work.         </p>
         <p>


### PR DESCRIPTION
Intended to address: concerns that the charter doesn't fully comply with the W3C Antitrust and Competition Guidance. Design teams are used by the WG to lead the creation of specifications and features, adding this text is intended to assure that these teams are constructed with the antitrust concerns in mind.

See https://github.com/patcg/patwg-charter/issues/44 to help with understanding this issue.