### PR TITLE
Clarify scope of group w/using open processes

### DIFF
--- a/charter.html
+++ b/charter.html
@@ -156,8 +156,8 @@
         <p>
             The Working Group will specify new web platform features intended to
             be implemented in browsers or similar user agents. The purpose of
-            these features is to support web advertising without compromising
-            user privacy.  Here "privacy" minimally refers to appropriate
+            these features is to support web advertising using an open and standardized 
+            protocol without compromising ser privacy.  Here "privacy" minimally refers to appropriate
             processing of personal information.  Ways in which new features might
             enable inappropriate processing include (but are not limited to)
             enabling


### PR DESCRIPTION
Intended to address concerns that the scope does not have clarity that the work of this group uses open and standardized protocols.

See https://github.com/patcg/patwg-charter/issues/44 to help with understanding this issue.