### PR TITLE
Make design teams work clearly under IPR

### DIFF
--- a/charter.html
+++ b/charter.html
@@ -374,6 +374,7 @@ To be successful, this Working Group is expected to have 6 or more active partic
         <p>
           At the discretion of the Chairs and subject to a consensus call, the Working Group may designate a Design Team to study a particular subject, and report back to the Working Group their findings and a recommendation. These Design Teams shall consist of a small group of volunteers who commit to investing significant amounts of time on the task over a short, time-bound, period.
         </p>
+        <p>Design teams will operate without putting forward any sensitive information. All teams should operate under the assumption that their data is under the IPR policy and potentially in the open.</p>
         <p>
           This Working Group primarily conducts its technical work in the PATWG GitHub repository, which is configured to send all issues and pull requests to the public mailing list: public-[email-list]@w3.org (archive). The public is invited to review, discuss and contribute to this work.         </p>
         <p>


### PR DESCRIPTION
Design teams work (like all work in the proposed WG) is under the W3C Intellectual Property Rights rules. However, this change intends to address concerns that the charter does not properly test acceptability of proposed deliverables. This change is intended to cover this concern by making it clear that we will not be producing work that isn't under open and under IPR.