### PR TITLE
Location of term definitions

### DIFF
--- a/charter.html
+++ b/charter.html
@@ -165,13 +165,18 @@
             or cross context recognition</a> of users or
             enabling <a href="https://w3ctag.github.io/privacy-principles/#hl-recognition-same-site">same-site
             or same-context recognition</a> of users across the clearing of
-            state.
+            state
         </p>
         <p>
           The Working Group may consider designs that allow user agents for the
           same user — including non-browser agents, like Operating Systems — to
           collaborate in providing advertising features.
           </p>
+        <p>
+          We will use the 
+          <a href="https://w3ctag.github.io/privacy-principles/#boring-terminology">definitions established by the W3C and TAG</a> 
+          exclusively when discussing features. If a term has multiple definitions and one of those is established by existing W3C 
+          documentation, the W3C documentation always provides the correct definition. 
         </p>
 
         <section id="section-out-of-scope">


### PR DESCRIPTION
This change is intended to address the concern that we might be using definitions of terms that don't match particular state, country, or industry definitions of terms, especially where those terms are defined differently by different entities. It is intended to make clear that where there are terms here that are unclear, like 'third party', based on the framework of the reader they should use the framework established by the W3C and TAG to understand those definitions. The goal is to assure all participants are on the same page.

See https://github.com/patcg/patwg-charter/issues/44 to help with understanding this issue.