### PR TITLE
An alternative approach for scoping

### DIFF
--- a/charter.html
+++ b/charter.html
@@ -175,10 +175,10 @@
         <p>
           The Working Group will produce specifications that are implemented by
           user agents.  The implementation of specifications in user agents
-          might depend on functionality provided by other entities.  In these
-          cases, the Working Group will <a href="#coordination">coordinate with
-          other organizations</a> to provide specifications for necessary
-          functions.
+          might interoperate with or depend on functionality provided by other
+          entities.  In these cases, the Working Group
+          will <a href="#coordination">coordinate with other organizations</a>
+          to provide specifications for necessary functions.
         </p>
 
         <section id="section-out-of-scope">

--- a/charter.html
+++ b/charter.html
@@ -160,8 +160,7 @@
       <section id="scope" class="scope">
         <h2>Scope</h2>
         <p>
-            The Working Group will specify new web platform features intended to
-            be implemented in browsers or similar user agents. The purpose of
+            The Working Group will specify new web platform features. The purpose of
             these features is to support web advertising without compromising
             user privacy.  Here "privacy" minimally refers to appropriate
             processing of personal information.  Ways in which new features might
@@ -174,10 +173,12 @@
             state.
         </p>
         <p>
-          The Working Group may consider designs that allow user agents for the
-          same user — including non-browser agents, like Operating Systems — to
-          collaborate in providing advertising features.
-          </p>
+          The Working Group will produce specifications that are implemented by
+          user agents.  The implementation of specifications in user agents
+          might depend on functionality provided by other entities.  In these
+          cases, the Working Group will <a href="#coordination">coordinate with
+          other organizations</a> to provide specifications for necessary
+          functions.
         </p>
 
         <section id="section-out-of-scope">


### PR DESCRIPTION
This is a bit of a departure from previous attempts at resolving this issue.

As I understand it, the core concern is that the scope of the working group needs to be fully within the scope of the W3C.  There are two relevant aspects to this that need explanation::

1. The functionality we build might depend on capabilities provided by entities that are not primarily "web" entities.  For instance, we have agreed that measurement will need some sort of *private computation*.  For this, I have added a paragraph that explicitly states that the working group will coordinate with other entities (IETF most likely) to ensure that those parts that need specification get specified properly.

2. The functionality we build might be better if the specification were implemented by non-web entities.  Here, there is ongoing discussion about what operating systems might do, or what capabilities might be built into connected TVs or point of sale devices in order to provide better value for measurement (attribution, reach, frequency, etc...).

I am suggesting that we NOT include any text for the latter.

There are obvious synergistic benefits to be had if the systems we are talking about are implemented more widely than just the web. However, functionally speaking, that is not something the W3C group can put into a charter.

That doesn't mean that what we do here won't matter or that it has no chance of affecting change in those non-web systems.  I believe that those synergistic benefits will encourage those who aim to support advertising in those systems to find ways to work with what we do for the web.  The web can be very influential.

A worked example might help.  When we did Web Push, we added a feature that was not previously part of any pre-existing push messaging system. Messages in Web Push are encrypted toward the recipient in a way that ensures that the push service cannot decrypt them.  This is now a standard feature of Google's FCM service, as used in most Android devices.  In that case, there was no network effect advantage to incentivize the use of encryption, but the work we did for the web showed how it was possible.  Google was under no obligation to provide this capability, but the benefits for user security and privacy were clearly justification enough.  Having the feature deployed on the web probably helped address any concerns about viability.

Finally, we are also not bound by charter NOT to talk about how the systems we build affect others.  I would contend that the charter explicitly requires that we consider the broader effect of choices we make, if only through its reference to ethical considerations.  While we make decisions for the web, those decisions have a wider impact and we have an obligation to try to understand and consider the implications of that.  That does not need to be reflected in charter text though, if only because it would be outside the remit of the organization.

Closes #50.
Closes #49.
More context in #44.

cc @hober, @AramZS, @seanturner.