### PR TITLE
Mark single-implementation features "at risk"

### DIFF
--- a/charter.html
+++ b/charter.html
@@ -266,15 +266,17 @@
     <a href="https://www.w3.org/2021/Process-20211102/#RecsWD">First Public
       Working Draft</a>,
     <a href="https://www.w3.org/2021/Process-20211102/#RecsWD">Working
-      Draft</a>,
-    <a href="https://www.w3.org/2021/Process-20211102/#candidate-recommendation-snapshot">Candidate
-      Recommendation Snapshot</a>, and <a href="https://www.w3.org/2021/Process-20211102/#candidate-recommendation-draft">Candidate
-      Recommendation Draft</a>. The WG does not intend to publish specifications as <a href="https://www.w3.org/2021/Process-20211102/#RecsPR">Proposed Recommendations</a>.
+      Draft</a>, and
+    <a href="https://www.w3.org/2021/Process-20211102/#RecsCR">Candidate
+      Recommendation</a>.
+      The WG does not intend to publish specifications as <a href="https://www.w3.org/2021/Process-20211102/#RecsPR">Proposed Recommendations</a>.
 
-          <p>To reach the Candidate Recommendation Snapshot stage, each normative
-            specification is expected to have <a href="https://www.w3.org/Consortium/Process/#implementation-experience">at
-              least two independent implementations</a> of every feature defined in the specification.
-            Interoperability of implementations will be verified by passing open test suites.
+          <p>It is expected that in <a
+          href="https://www.w3.org/2021/Process-20211102/#RecsCR">Candidate Recommendations</a>,
+          every feature that doesn't have <a
+          href="https://www.w3.org/Consortium/Process/#implementation-experience">at least two
+          independent implementations</a> will be clearly marked "at risk".
+          Interoperability of implementations will be verified by passing open test suites.
 
           <p>Each normative specification should contain separate sections detailing security and privacy implications for implementers, Web authors, and end users.</p>
 
@@ -282,8 +284,8 @@
           aspects of normative specifications developed by the WG.
 
     <p>Normative specifications which have user-facing features should contain a section on accessibility that describes the benefits and impacts, including ways specification features can be used to address them, and recommendations for maximizing accessibility in implementations.</p>
-          
-    <p>In considering features, the group will state, during the development of those features or in the text of the document, privacy implications. Proposals should clearly state privacy issues, how they intend to address those issues, and the advertising use cases addressed in each deliverable.</p>          
+
+    <p>In considering features, the group will state, during the development of those features or in the text of the document, privacy implications. Proposals should clearly state privacy issues, how they intend to address those issues, and the advertising use cases addressed in each deliverable.</p>
         </section>
 
       <section id="coordination">


### PR DESCRIPTION
Instead of distinguishing the CR-draft stage.

Fixes #42 if @tantek agrees.