### PR TITLE
Indicate no draft for private attribution measurement

### DIFF
--- a/charter.html
+++ b/charter.html
@@ -92,9 +92,9 @@
       </div>
 
          <p style="padding: 0.5ex; border: 1px solid green"> This proposed charter is available
-      on <i class="todo"><a href="https://github.com/patcg/patwg-charter/">GitHub</a>.
+      on <a href="https://github.com/patcg/patwg-charter/">GitHub</a>.
 
-    Feel free to raise <a href="https://github.com/patcg/patwg-charter/issues">issues</a></i>.
+    Feel free to raise <a href="https://github.com/patcg/patwg-charter/issues">issues</a>.
           </p>
 
       <section id="details">
@@ -205,9 +205,11 @@
             The Working Group will deliver the following W3C normative specifications:
           </p>
           <dl>
-            <dt id="private-attribution" class="spec"><a href="#">Private Attribution Measurement</a></dt>
+            <dt id="private-attribution" class="spec"><a href="https://github.com/patcg/private-measurement">Private Attribution Measurement</a></dt>
             <dd>
               <p>This specification defines how to privately measure advertisement attribution/conversion rates without revealing whether any individual user converts or does not.</p>
+              <p class="draft-status"><b>Draft state:</b> No draft</p>
+              <p class="milestone"><b>Expected completion:</b> Q3 2025</p>
             </dd>
           </dl>
 


### PR DESCRIPTION
Indicate that the WG has not yet adopted a baseline document for the attribution measurement deliverable.

Also remove a spurious todo