### PR TITLE
rename Design Teams to task forces

### DIFF
--- a/charter.html
+++ b/charter.html
@@ -383,10 +383,9 @@ To be successful, this Working Group is expected to have 6 or more active partic
 
         </p>
         <p>
-          At the discretion of the Chairs and subject to a consensus call, the Working Group may designate a Design Team to study a particular subject, and report back to the Working Group their findings and a recommendation. These Design Teams shall consist of a small group of volunteers who commit to investing significant amounts of time on the task over a short, time-bound, period.
+          At the discretion of the Chairs and subject to a consensus call, the Working Group may designate a task force to study a particular subject and report back to the Working Group their findings and a recommendation. A task force will consist of a small group of volunteers who commit to investing significant amounts of time on the task over a short, time-bound, period.
         </p>
-        <p>Design Teams operate under the same policies as the Working Group.
-For example, the same IPR commitments apply to Design Team contributions as Working Group contributions.</p>
+        <p>Task forces operate under the same policies as the Working Group.</p>
         <p>
           This Working Group primarily conducts its technical work in the PATWG GitHub repository, which is configured to send all issues and pull requests to the public mailing list: public-[email-list]@w3.org (archive). The public is invited to review, discuss and contribute to this work.         </p>
         <p>


### PR DESCRIPTION
As called out by Chris Lilley and consistent with Process section 3.4.1, use the name "task force". https://www.w3.org/2021/Process-20211102/#ReqsAllGroups

Also removed an unneeded comma and simplified language.