### PR TITLE
Adding detail and sources to specification process for first proposal.

### DIFF
--- a/charter.html
+++ b/charter.html
@@ -210,6 +210,16 @@
               <p>This specification defines how to privately measure advertisement attribution/conversion rates without revealing whether any individual user converts or does not.</p>
               <p class="draft-status"><b>Draft state:</b> No draft</p>
               <p class="milestone"><b>Expected completion:</b> Q3 2025</p>
+			  <p>The proposal will work with concepts and take inspiration from:</p>
+			  <ul>
+				<li><a href="https://github.com/patcg-individual-drafts/ipa"></a>Interoperable Private Attribution (IPA)</li>
+				<li><a href="https://github.com/privacycg/private-click-measurement/">Private Click Measurement</a></li>
+				<li><a href="https://github.com/patcg-individual-drafts/private-aggregation-api">Private Aggregation API</a></li>
+				<li><a href="https://github.com/wicg/attribution-reporting-api">Attribution Reporting API</a></li>
+			  </ul>
+			  <p>
+				The proposal will arise from the dimensions set in the <a href="https://github.com/patcg/docs-and-reports/tree/main/design-dimensions">Design Dimensions document</a> and will be guided by the <a href="https://github.com/patcg/docs-and-reports/tree/main/threat-model">threat model</a> and <a href="https://github.com/patcg/docs-and-reports/tree/main/principles">principles documents</a> initiated by PATCG.
+			  </p>
             </dd>
           </dl>
 

--- a/charter.html
+++ b/charter.html
@@ -216,6 +216,7 @@
 				<li><a href="https://github.com/privacycg/private-click-measurement/">Private Click Measurement</a></li>
 				<li><a href="https://github.com/patcg-individual-drafts/private-aggregation-api">Private Aggregation API</a></li>
 				<li><a href="https://github.com/wicg/attribution-reporting-api">Attribution Reporting API</a></li>
+				<li><a href="https://github.com/patcg-individual-drafts/private-ad-measurement">Prio-like Attribution Measurement</a></li>
 			  </ul>
 			  <p>
 				The proposal will arise from the dimensions set in the <a href="https://github.com/patcg/docs-and-reports/tree/main/design-dimensions">Design Dimensions document</a> and will be guided by the <a href="https://github.com/patcg/docs-and-reports/tree/main/threat-model">threat model</a> and <a href="https://github.com/patcg/docs-and-reports/tree/main/principles">principles documents</a> initiated by PATCG.

--- a/charter.html
+++ b/charter.html
@@ -207,7 +207,7 @@
           <dl>
             <dt id="private-attribution" class="spec"><a href="https://github.com/patcg/private-measurement">Private Attribution Measurement</a></dt>
             <dd>
-              <p>This specification defines how to privately measure advertisement attribution/conversion rates without revealing whether any individual user converts or does not.</p>
+              <p>This specification defines how to privately measure advertisement attribution/conversion without revealing whether any individual user converts or does not.</p>
               <p class="draft-status"><b>Draft state:</b> No draft</p>
               <p class="milestone"><b>Expected completion:</b> Q3 2025</p>
 			  <p>The proposal will work with concepts and take inspiration from:</p>


### PR DESCRIPTION
In order to be clear about the origins of the first specification that will be the work of the WG we should make it clear that the specification will be arising from specific preexisting proposals and documents we intend to use as resources and initial starting points for the final specification. This adds a (non-exclusive) list to make that clear. 