### PR TITLE
A first run on motivation and background

### DIFF
--- a/charter.html
+++ b/charter.html
@@ -157,7 +157,25 @@
           </tr>
         </table>
 
-      <section id="scope" class="scope">
+    <section id="background" class="background">
+        <h2>Motivation and Background</h2>
+        <h3>Origins</h3>
+        <p>
+            The Private Advertising Technology Working Group arose from efforts to implement privacy-forward technology and standards which support and evolve use cases that, until this point, have been dependent on third-party cookies and other tracking mechanisms. The initial approach to this topic was at the <a href="https://www.w3.org/community/web-adv/" target="_blank">Improving Web Advertising Business Group</a> which worked to define requirements and engage with the community to understand the needs of the advertising ecosystem. The work that started there has generated work taken up by a variety of other, more focused, groups.
+        </p>
+        <p>
+            The groups that formed to help generate new standards and processes around privacy technologies at the W3C included the Private Advertising Technology Community Group (PATCG). This group has taken up community engagement to incubate web features and APIs that support advertising while acting in the interests of users, in particular providing strong privacy assurances using predominantly technical means. Some of the work incubated in that group has become mature enough to be taken up by a Working Group. This group was proposed to be chartered to take up work which reaches that state in PATCG. It also is prepared for work that matches our <a href="#mission">mission</a> and <a href="#scope">scope</a> and is ready to be taken up by a working group. 
+        </p>
+        <h3>Motivation</h3>
+        <p>
+            This group is motivated by our <a href="#mission">mission</a> and the need for a commercially sustainable web. We understand that such a web is accessed through user agents and those user agents should act in the interest of their users and provide strong assurances of privacy. Our concerns are focused on supporting and creating an environment where the many ad-driven stakeholders who build the web, and are interested in operating within the limitations of our <a href="#scope">scope</a>, can find usable and useful processes by which to operate. 
+        </p>
+        <p>
+            The work of privacy enhanced advertising technology is not limited to this group or even the W3C, however we believe we are best placed to bring together users, developers, and industry and serve all in a balanced fashion on this particular subset of that work. 
+        </p>
+    </section>
+
+    <section id="scope" class="scope">
         <h2>Scope</h2>
         <p>
             The Working Group will specify new web platform features. The purpose of


### PR DESCRIPTION
This is an attempt to meet expectations that come with the new template for charters by providing a Motivation and Background section, as noted in #72. 

You may note that it has a lot of overlap with Scope and Mission. Yes. It does. I didn't see any way around that overlap that would allow us to accurately describe motivation, so I just put it in. 

This is very much a first draft meant to encourage discussion, but I'd like to close out work on this section at TPAC; so please bring out your knives and cut away, but do so sooner rather than later. 