### PR TITLE
missing comma?

### DIFF
--- a/charter.html
+++ b/charter.html
@@ -76,7 +76,7 @@
       <h1 id="title">PROPOSED Private Advertising Technology Working Group Charter</h1>
       <!-- delete PROPOSED after AC review completed -->
 
-      <p class="mission">The <strong>mission</strong> of the <a href="">Private Advertising Technology Working Group</a>
+      <p class="mission">The <strong>mission</strong> of the <a href="">Private Advertising Technology Working Group</a>,
          motivated by the <a href="https://www.w3.org/2001/tag/doc/ethical-web-principles/">W3C TAG Ethical Web Principles</a>, is to
          specify web features and APIs that support advertising while
          acting in the interests of users, in particular providing strong


### PR DESCRIPTION
I'm not sure when this comma went walkabout, but I think it belongs in the doc.