### PR TITLE
Timeline updates

### DIFF
--- a/charter.html
+++ b/charter.html
@@ -279,10 +279,9 @@
         <section id="timeline">
           <h3>Timeline</h3>
             <ul>
-              <li>Sept 2023: First face-to-face at TPAC</li>
-              <li>October 2023: First teleconference meeting</li>
               <li>March 2024: Requirements and Use Cases Established for Private Measurement</li>
               <li>May 2024: First Draft for Private Measurement</li>
+              <li>June 2024: First face-to-face meeting (tentative)</li>
             </ul>
         </section>
       </section>


### PR DESCRIPTION
Two charter reviewers called out that the timeline in section 3.3 has been overtaken by events - the WG was not chartered in time for meetings in September and October 2023.

This PR removes those past dates, proposes a first f2f in June 2024, and does not otherwise adjust the milestones.