### PR TITLE
Update document status page url in the charter page

### DIFF
--- a/charter.html
+++ b/charter.html
@@ -210,7 +210,7 @@
           Deliverables
         </h2>
 
-        <p><i class="todo">Updated document status is available on the <a href="https://www.w3.org/groups/wg/[shortname]/publications">group publication status page</a>.</i></p>
+        <p><i class="todo">Updated document status is available on the <a href="https://patcg.github.io/docs-and-reports/">group publication status page</a>.</i></p>
 
         <p><i>Draft state</i> indicates the state of the deliverable at the time of the charter approval.
           The Working Group intends to publish the latest state of their work as Candidate Recommendation (with Snapshots) and does not intend to advance their documents further in this charter period.</p>


### PR DESCRIPTION
Update document status page url. The old url is broken. Suggested to update the most up to date our docs & report page